### PR TITLE
Added CMAKE BUILD TYPE flag for performance improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 2.6.2)
 
 add_compile_options(-std=c++11)
 
+set(CMAKE_BUILD_TYPE "Release")
+
 enable_testing()
 
 project( Mesher )


### PR DESCRIPTION
Described in a CGAL compiler warning on Ubuntu 20.04. 
This should trigger Travis shouldnt it?